### PR TITLE
Enabling privacy settings for web administrators

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# PHP PSR-2 Coding Standards
+# http://www.php-fig.org/psr/psr-2/
+
+root = true
+
+[*.php]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -29,7 +29,7 @@ class Utils
     public static function getWpRolesObject()
     {
         global $wp_roles;
-        if ( ! isset($wp_roles)) {
+        if (!isset($wp_roles)) {
             $wp_roles = new WP_Roles();
         }
 
@@ -65,4 +65,3 @@ class Utils
         }
     }
 }
-

--- a/src/WebAdministrator.php
+++ b/src/WebAdministrator.php
@@ -38,6 +38,7 @@ class WebAdministrator
             'edit_users',
             'delete_users',
             'edit_theme_options',
+            'manage_privacy_options',
         ];
         foreach ($additionalCapabilities as $cap) {
             $web_administrator->add_cap($cap);

--- a/src/hooks.php
+++ b/src/hooks.php
@@ -3,6 +3,7 @@
 namespace MOJDigital\UserRoles;
 
 use WP_User;
+use WP_Privacy_Policy_Content;
 
 /**
  * Class Hooks
@@ -97,6 +98,77 @@ class Hooks
     }
 
     /**
+     * Filter map_meta_cap to add support for 'manage_privacy_options' capability
+     *
+     * By default, WordPress maps the cap 'manage_privacy_options' to 'manage_options'
+     * However we grant 'manage_privacy_options' as a capability in its own right
+     * to some user roles (i.e. Web Administrators).
+     * So if the user does not have 'manage_options' capability (i.e. if they're not an admin),
+     * then don't map 'manage_privacy_options' to 'manage_options'
+     * In practice, this is implemented as mapping 'manage_privacy_options' to
+     * itself ('manage_privacy_options')
+     *
+     * @param array $caps The user's actual capabilities.
+     * @param string $cap Capability name.
+     * @param int $user_id The user id.
+     * @param array $args Adds the context to the cap. Typically the object ID.
+     *
+     * @return array The user's actual capabilities.
+     */
+    public static function managePrivacyOptionsCap($caps, $cap, $user_id, $args)
+    {
+        if ($cap == 'manage_privacy_options' && !user_can($user_id, 'manage_options')) {
+            $caps = ['manage_privacy_options'];
+        }
+        return $caps;
+    }
+
+    /**
+     * Give a 'Privacy Settings' admin menu item to users who have permission to
+     * 'manage_privacy_options' but not to 'manage_options'.
+     * Without this, the 'Privacy Settings' page becomes inaccessible due to the
+     * user not having permission to access the top-level 'Settings' page.
+     */
+    public static function privacySettingsAdminMenu()
+    {
+        global $menu, $submenu;
+
+        // Don't change anything if this is an admin user
+        // Leave the Privacy submenu item under the Settings menu
+        if (current_user_can('manage_options')) {
+            return;
+        }
+
+        // phpcs:disable
+        // Shamelessly stolen from WordPress's original implementation of the Settings menu
+        // This will notify when there are suggested changes for the Privacy page
+        // Source: wp-admin/menu.php
+        // Link: https://github.com/WordPress/WordPress/blob/d1802a68ec7a3536f744d45afb72660e4fef0292/wp-admin/menu.php#L252-L255
+        $change_notice = '';
+        if ( current_user_can( 'manage_privacy_options' ) && WP_Privacy_Policy_Content::text_change_check() ) {
+            $change_notice = ' <span class="update-plugins 1"><span class="plugin-count">' . number_format_i18n( 1 ) . '</span></span>';
+        }
+        // phpcs:enable
+
+        // Add a new Privacy menu item directly after Settings
+        // In this case, we know Settings will be hidden anyway, so this will
+        // effectively sit in its place
+        $menu[81] = [
+            sprintf('Privacy %s', $change_notice),
+            'manage_privacy_options',
+            'privacy.php',
+            '',
+            'menu-top menu-icon-settings',
+            'menu-settings',
+            'dashicons-shield',
+        ];
+
+        // Move the Privacy submenu item from Settings to our new Privacy menu item
+        $submenu['privacy.php'][10] = $submenu['options-general.php'][45];
+        unset($submenu['options-general.php'][45]);
+    }
+
+    /**
      * Register actions and filters for the new roles.
      */
     public static function apply()
@@ -104,5 +176,7 @@ class Hooks
         add_filter('editable_roles', __CLASS__ . '::filterEditableRoles', 10, 1);
         add_filter('map_meta_cap', __CLASS__ . '::filterPreventModificationOfAdminUser', 10, 4);
         add_action('admin_menu', __CLASS__ . '::actionRestrictAppearanceThemesMenu', 999);
+        add_filter('map_meta_cap', __CLASS__ . '::managePrivacyOptionsCap', 10, 4);
+        add_action('_admin_menu', __CLASS__ . '::privacySettingsAdminMenu');
     }
 }


### PR DESCRIPTION
Check out this plugin to web/app/plugins/

You should see that the `Settings` options are restricted to just the Privacy sub menu page, and whatever other plugins pages may exist there too.